### PR TITLE
Avoid crash when no app can open a tapped link

### DIFF
--- a/app/src/main/java/com/appmindlab/nano/DisplayDBEntry.java
+++ b/app/src/main/java/com/appmindlab/nano/DisplayDBEntry.java
@@ -1696,7 +1696,11 @@ public class DisplayDBEntry extends AppCompatActivity implements PopupMenu.OnMen
                         intent.setData(Uri.parse(url));
                     }
 
-                    view.getContext().startActivity(intent);
+                    try {
+                        view.getContext().startActivity(intent);
+                    } catch (android.content.ActivityNotFoundException e) {
+                        Toast.makeText(view.getContext(), R.string.error_no_app_to_open, Toast.LENGTH_SHORT).show();
+                    }
                     return true;
                 } else {
                     return false;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -197,6 +197,7 @@
     <string name="error_network">No network.</string>
     <string name="error_json">JSON error.</string>
     <string name="error_resource_not_found">Requested resource not found.</string>
+    <string name="error_no_app_to_open">No app found to open this.</string>
     <string name="error_unexpected">Unexpected error.</string>
     <string name="error_login">Login did not connect. Status is </string>
     <string name="error_empty_title">Please enter a title.</string>


### PR DESCRIPTION
`handleUrlLoading` in the markdown view calls `startActivity` with `ACTION_VIEW` to open a tapped link or file reference. If no app can handle the target, for example a `tel:` link with no dialer or a file type with no viewer, the call throws `ActivityNotFoundException` and the note screen crashes.

This wraps that call in a try and catch. When no app can handle the target a short message is shown and the note stays open. Normal links keep opening the same way. One string is added for the message.

Closes #112
